### PR TITLE
clear some warnings

### DIFF
--- a/samples/rust/rust_kvm/exit.rs
+++ b/samples/rust/rust_kvm/exit.rs
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0
-use super::{Guest, GuestWrapper};
-use super::{Pio, Vcpu, VcpuWrapper};
+use super::VcpuWrapper;
 use crate::mmu::*;
 use crate::vmcs::*;
 use core::mem::MaybeUninit;
 use kernel::prelude::*;
-use kernel::{bindings, bit, c_types::c_void, pages::Pages, sync::Ref, Error, Result, PAGE_SIZE};
+use kernel::{bindings, bit, sync::Ref, Error, Result, PAGE_SIZE};
 
 #[repr(u32)]
 #[derive(Debug, Copy, Clone)]
@@ -323,8 +322,8 @@ pub(crate) fn handle_io(exit_info: &ExitInfo, vcpu: &VcpuWrapper) -> Result<u64>
 
 pub(crate) fn handle_ept_misconfig(exit_info: &ExitInfo, vcpu: &VcpuWrapper) -> Result<u64> {
     pr_info!("Enter handle EPT misconfiguration\n");
-    let mut error_code: u64 = 0;
-    let gpa = vmcs_read64(VmcsField::GUEST_PHYSICAL_ADDRESS);
+    // let mut error_code: u64 = 0;
+    let _gpa = vmcs_read64(VmcsField::GUEST_PHYSICAL_ADDRESS);
     exit_info.next_rip();
     Ok(0)
 }
@@ -361,7 +360,7 @@ fn rkvm_pagefault(vcpu: &VcpuWrapper, fault: &mut RkvmPageFault) -> Result {
         return Err(Error::EINVAL);
     }
     fault.hva = uaddr + (fault.gfn - base_gfn) * kernel::PAGE_SIZE as u64;
-    let mut flags: u32 = bindings::FOLL_HWPOISON | bindings::FOLL_NOWAIT;
+    let flags: u32 = bindings::FOLL_HWPOISON | bindings::FOLL_NOWAIT;
 
     let mut nrpages: i64 = 0;
     let mut pages = MaybeUninit::<*mut bindings::page>::uninit();
@@ -471,14 +470,14 @@ fn make_noleaf_spte(pt: u64, flags: &EptMasks) -> u64 {
 fn rkvm_tdp_map(vcpu: &VcpuWrapper, fault: &mut RkvmPageFault) -> Result {
     let mut level: u64 = 4;
     let mut vcpuinner = vcpu.vcpuinner.lock();
-    let mut level_gfn = make_level_gfn(fault.gfn, level);
+    let level_gfn = make_level_gfn(fault.gfn, level);
     let mut level_gfn = match level_gfn {
         Ok(gfn) => gfn,
         Err(e) => return Err(e),
     };
     let mut pre_mmu_page = vcpuinner.mmu.root_mmu_page.clone();
     let flags = vcpuinner.mmu.spte_flags.clone();
-    let mut spte = rkvm_read_spte(pre_mmu_page.clone(), level_gfn, level);
+    let spte = rkvm_read_spte(pre_mmu_page.clone(), level_gfn, level);
     let mut spte = match spte {
         Err(err) => return Err(err),
         Ok(spte) => spte,
@@ -488,7 +487,7 @@ fn rkvm_tdp_map(vcpu: &VcpuWrapper, fault: &mut RkvmPageFault) -> Result {
             break;
         }
         if !vcpuinner.mmu.is_pte_present(spte) {
-            let mut mmu_page = vcpuinner.mmu.alloc_mmu_page(level - 1, level_gfn)?;
+            let mmu_page = vcpuinner.mmu.alloc_mmu_page(level - 1, level_gfn)?;
             let child_spt = match mmu_page.spt {
                 Some(spt) => spt,
                 None => return Err(Error::ENOMEM),

--- a/samples/rust/rust_kvm/mmu.rs
+++ b/samples/rust/rust_kvm/mmu.rs
@@ -141,7 +141,7 @@ impl RkvmMmu {
         unsafe {
             bindings::memset(ptr, 0, PAGE_SIZE as u64);
         }
-        let mut hpa = unsafe { bindings::rkvm_phy_address(hpa) };
+        let hpa = unsafe { bindings::rkvm_phy_address(hpa) };
         pr_info!("RkvmMmu hpa(phy) = {:x}--root_hpa \n", hpa);
 
         let flags = EptMasks::new();

--- a/samples/rust/rust_kvm/rust_kvm.rs
+++ b/samples/rust/rust_kvm/rust_kvm.rs
@@ -24,10 +24,10 @@ mod vmcs;
 mod vmstat;
 mod x86reg;
 
-use crate::guest::{Guest, GuestWrapper};
+use crate::guest::GuestWrapper;
 use crate::vcpu::*;
 use crate::vmcs::*;
-use crate::x86reg::Cr4;
+
 
 module! {
     type: RustMiscdev,
@@ -56,7 +56,7 @@ impl RkvmState {
     fn try_new() -> Result<Ref<Self>> {
         pr_info!("RkvmState try_new \n");
         let mut vmcsconf = VmcsConfig::new()?;
-        let ret = vmcsconf.setup_config()?;
+        let _ret = vmcsconf.setup_config()?;
         let mut state = Pin::from(UniqueRef::try_new(Self {
             // SAFETY: `condvar_init!` is called below.
             state_changed: unsafe { CondVar::new() },

--- a/samples/rust/rust_kvm/vcpu.rs
+++ b/samples/rust/rust_kvm/vcpu.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0
-use super::{Guest, GuestWrapper};
+use super::GuestWrapper;
 use crate::exit::*;
 use crate::mmu::*;
 use crate::vmcs::*;
 use crate::vmstat::*;
-use crate::x86reg::*;
 use core::arch::global_asm;
 use core::pin::Pin;
 use kernel::bindings;
@@ -205,7 +204,7 @@ pub(crate) fn alloc_vmcs(revision_id: u32) -> Result<RkvmPage<RkvmVmcs>> {
         Ok(page) => page,
         Err(err) => return Err(err),
     };
-    let mut vmcs = RkvmPage::<RkvmVmcs>::new(page);
+    let vmcs = RkvmPage::<RkvmVmcs>::new(page);
     //unsafe { (*vmcs.ptr).revision_id = revision_id; }
     let ptr = vmcs.va as *mut u32;
     unsafe {
@@ -255,7 +254,7 @@ impl VcpuWrapper {
 
         let mmu = RkvmMmu::new();
 
-        let mut mmu = match mmu {
+        let mmu = match mmu {
             Ok(mmu) => mmu,
             Err(err) => return Err(err),
         };
@@ -305,7 +304,7 @@ impl VcpuWrapper {
                 let vector_info = vmcs_read32(VmcsField::IDT_VECTORING_INFO);
                 if vector_info & 0x80000000 != 0 {
                     pr_info!(" EPT_MISCONFIGURATION, vector_info: {:x} \n", vector_info);
-                    let mut vcpuinner = self.vcpuinner.lock();
+                    let vcpuinner = self.vcpuinner.lock();
                     let ptr = (vcpuinner.run.va + 8) as *mut u64;
                     unsafe {
                         (*ptr) = 2;
@@ -321,7 +320,7 @@ impl VcpuWrapper {
             }
             _ => {
                 pr_info!(" ## exit_reason = {:?} \n", exit_info.exit_reason);
-                let mut vcpuinner = self.vcpuinner.lock();
+                let vcpuinner = self.vcpuinner.lock();
                 let ptr = (vcpuinner.run.va + 8) as *mut u64;
                 unsafe {
                     (*ptr) = exit_info.exit_reason as u64;
@@ -350,7 +349,7 @@ impl VcpuWrapper {
             }
             let has_err_;
             {
-                let mut vcpuinner = self.vcpuinner.lock();
+                let vcpuinner = self.vcpuinner.lock();
 
                 let launched = vcpuinner.guest_state.launched;
 
@@ -406,7 +405,7 @@ impl VcpuWrapper {
                         return r.try_into().unwrap();
                     }
                 }
-                Err(err) => {
+                Err(_err) => {
                     let mut vcpuinner = self.vcpuinner.lock();
                     pr_info!("  vcpu run failed \n");
                     dump_vmcs();
@@ -449,7 +448,7 @@ impl VcpuWrapper {
     }
 
     pub(crate) fn get_regs(&self, regs: &mut RkvmRegs) {
-        let mut vcpuinner = self.vcpuinner.lock();
+        let vcpuinner = self.vcpuinner.lock();
         vmcs_load(vcpuinner.vmcs.va);
         //let guest_state = &vcpuinner.guest_state;
         regs.rax = vcpuinner.guest_state.rax;
@@ -473,7 +472,7 @@ impl VcpuWrapper {
     }
 
     pub(crate) fn set_sregs(&self, sregs: &RkvmSregs) {
-        let mut vcpuinner = self.vcpuinner.lock();
+        let vcpuinner = self.vcpuinner.lock();
         vmcs_load(vcpuinner.vmcs.va);
         let base = sregs.cs.base;
         let selector = sregs.cs.selector;
@@ -482,7 +481,7 @@ impl VcpuWrapper {
     }
 
     pub(crate) fn get_sregs(&self, sregs: &mut RkvmSregs) {
-        let mut vcpuinner = self.vcpuinner.lock();
+        let vcpuinner = self.vcpuinner.lock();
         vmcs_load(vcpuinner.vmcs.va);
         sregs.cs.base = vmcs_read64(VmcsField::GUEST_CS_BASE);
         sregs.cs.selector = vmcs_read16(VmcsField::GUEST_CS_SELECTOR);

--- a/samples/rust/rust_kvm/vmcs.rs
+++ b/samples/rust/rust_kvm/vmcs.rs
@@ -358,8 +358,8 @@ pub(crate) fn read_msr(msr: X86Msr) -> u64 {
     val
 }
 
-const X86_EFER_LME: u64 = 0x00000100; /* long mode enable */
-const X86_EFER_LMA: u64 = 0x00000400; /* long mode active */
+// const X86_EFER_LME: u64 = 0x00000100; /* long mode enable */
+// const X86_EFER_LMA: u64 = 0x00000400; /* long mode active */
 
 fn set_control(field: VmcsField, true_msr: u64, old_msr: u64, set: u32, clear: u32) -> Result<u32> {
     let allowed_0 = true_msr as u32;
@@ -384,7 +384,7 @@ fn set_control(field: VmcsField, true_msr: u64, old_msr: u64, set: u32, clear: u
     let unknown = flexible & !(set | clear);
     let defaults = unknown & old_msr as u32;
 
-    Ok((allowed_0 | defaults | set))
+    Ok(allowed_0 | defaults | set)
 }
 
 pub(crate) fn dump_vmcs() {
@@ -620,7 +620,7 @@ impl VmcsConfig {
         let mut cr0 = unsafe { bindings::native2_read_cr0() };
         cr0 &= !(Cr0::CR0_TS as u64);
         let cr3 = unsafe { bindings::native2_read_cr3() };
-        let cr4 = unsafe { bindings::cr4_read_shadow() };
+        // let cr4 = unsafe { bindings::cr4_read_shadow() };
         vmcs_write64(VmcsField::HOST_CR0, cr0);
         vmcs_write64(VmcsField::HOST_CR3, cr3);
         vmcs_write64(VmcsField::HOST_CR4, 0x7726e0);
@@ -763,10 +763,10 @@ impl VmcsConfig {
         let pat = read_msr(X86Msr::PAT);
         vmcs_write64(VmcsField::GUEST_IA32_PAT, 0x7040600070406);
         vmcs_write64(VmcsField::HOST_IA32_PAT, pat);
-        let mut efer = read_msr(X86Msr::EFER);
+        let efer = read_msr(X86Msr::EFER);
         vmcs_write64(VmcsField::HOST_IA32_EFER, efer);
         pr_info!(" host_efer = {:x} \n", efer);
-        efer &= !(X86_EFER_LME | X86_EFER_LMA);
+        // efer &= !(X86_EFER_LME | X86_EFER_LMA);
         vmcs_write64(VmcsField::GUEST_IA32_EFER, /*efer*/ 0);
         vmcs_write32(VmcsField::CR3_TARGET_COUNT, 0);
         vmcs_write64(VmcsField::TSC_OFFSET, 0);

--- a/samples/rust/rust_kvm/vmstat.rs
+++ b/samples/rust/rust_kvm/vmstat.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: GPL-2.0
-use kernel::prelude::*;
 
 #[repr(C)]
 #[allow(dead_code)]


### PR DESCRIPTION
- Clear some warnings related to unused import, unused veriable, mutable borrow and inner veriable name.

- Remain warnings related to unsolved return value of Result::Err

Signed-off-by: Zhou Haoan <tvavbb@126.com>