### PR TITLE
Refactor rkvm_irq_enable/disable, read/write_cr4, vmxon  in rust inline asm

### DIFF
--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -80,7 +80,6 @@ unsigned long native2_read_cr3(void);
 unsigned long native2_read_cr4(void);
 void native_write_cr4(unsigned long val);
 unsigned long cr4_read_shadow(void);
-void rkvm_vmxon(u64 addr);
 void rkvm_vmxoff(void);
 
 void rkvm_wrgsbase(unsigned long gs);

--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -92,8 +92,6 @@ unsigned short rkvm_read_ldt(void);
 void rkvm_load_ldt(unsigned short sel);
 
 u64 rkvm_rflags_read(void);
-void rkvm_irq_disable(void);
-void rkvm_irq_enable(void);
 
 #ifdef CONFIG_X86_INTEL_MEMORY_PROTECTION_KEYS
 static inline u32 rdpkru(void)

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -434,16 +434,6 @@ unsigned long __no_profile native2_read_cr0(void)
 }
 EXPORT_SYMBOL_GPL(native2_read_cr0);
 
-void rkvm_vmxon(u64 addr)
-{
-	unsigned long cr4;
-	cr4 = native_read_cr4();
-	cr4 |= X86_CR4_VMXE;
-	native_write_cr4(cr4);
-	asm volatile ("vmxon %0" : : "m"(addr));
-}
-EXPORT_SYMBOL(rkvm_vmxon);
-
 void rkvm_vmxoff()
 {
 	unsigned long cr4;

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -504,18 +504,6 @@ u64 rkvm_rflags_read()
 }
 EXPORT_SYMBOL(rkvm_rflags_read);
 
-void rkvm_irq_disable(void)
-{
-       asm volatile("cli": : :"memory");
-}
-EXPORT_SYMBOL(rkvm_irq_disable);
-
-void rkvm_irq_enable(void)
-{
-        asm volatile("sti": : :"memory");
-}
-EXPORT_SYMBOL(rkvm_irq_enable);
-
 void cr4_update_irqsoff(unsigned long set, unsigned long clear)
 {
 	unsigned long newval, cr4 = this_cpu_read(cpu_tlbstate.cr4);

--- a/samples/rust/rust_kvm/rust_kvm.rs
+++ b/samples/rust/rust_kvm/rust_kvm.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
 
 //! Rust KVM for VMX
+use core::arch::asm;
 #[allow(missing_docs)]
 use kernel::c_types::c_void;
 use kernel::mm::virt::Area;
@@ -153,6 +154,20 @@ impl Drop for RustMiscdev {
 }
 
 static mut VMXON_VMCS: Option<RkvmPage<RkvmVmcs>> = None;
+fn rkvm_vmxon(addr: u64) {
+    let mut cr4: u64 = read_cr4();
+    cr4 |= Cr4::CR4_ENABLE_VMX as u64;
+    write_cr4(cr4);
+    rkvm_debug!("written new cr4 value\n");
+    unsafe {
+        asm!(
+            "vmxon ({0})",
+            in(reg) &addr,
+            options(att_syntax)
+        );
+    }
+}
+
 fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
     let revision_id = state.inner.lock().vmcsconf.revision_id;
     let vmcs = alloc_vmcs(revision_id);
@@ -161,7 +176,7 @@ fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
         Err(err) => return Err(/*Error::ENOMEM*/ err),
     };
 
-    let vmxe = unsafe { bindings::native2_read_cr4() & bit(x86reg::Cr4::CR4_ENABLE_VMX) };
+    let vmxe = unsafe { bindings::native2_read_cr4() & Cr4::CR4_ENABLE_VMX as u64 };
 
     rkvm_debug!("Rust kvm :vmxe {:}\n", vmxe);
 
@@ -174,7 +189,7 @@ fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
 
         rkvm_debug!(" pa = {:x}\n", pa);
 
-        bindings::rkvm_vmxon(pa);
+        rkvm_vmxon(pa);
         VMXON_VMCS = Some(vmcs);
     }
     Ok(0)

--- a/samples/rust/rust_kvm/vcpu.rs
+++ b/samples/rust/rust_kvm/vcpu.rs
@@ -230,23 +230,19 @@ pub(crate) fn alloc_vmcs(revision_id: u32) -> Result<RkvmPage<RkvmVmcs>> {
 }
 
 fn vmcs_load(va: u64) {
-    let phy = unsafe {
-        bindings::rkvm_phy_address(va)
-    };
+    let phy = unsafe { bindings::rkvm_phy_address(va) };
     if phy == 0 {
-       pr_err!(" vmcs_load failed \n");
+        pr_err!(" vmcs_load failed \n");
     }
     if vmptrld(phy).is_err() {
-       pr_info!(" vmptrld failed phy={:x} \n", phy);
+        pr_info!(" vmptrld failed phy={:x} \n", phy);
     }
 }
 
 fn vmcs_clear(va: u64) {
-    let phy = unsafe {
-        bindings::rkvm_phy_address(va)
-    };
+    let phy = unsafe { bindings::rkvm_phy_address(va) };
     if vmclear(phy).is_err() {
-       pr_info!(" vmclear failed phy={:x} \n", phy);
+        pr_info!(" vmclear failed phy={:x} \n", phy);
     }
 }
 

--- a/samples/rust/rust_kvm/vcpu.rs
+++ b/samples/rust/rust_kvm/vcpu.rs
@@ -5,7 +5,7 @@ use crate::mmu::*;
 use crate::vmcs::*;
 use crate::vmstat::*;
 use crate::{rkvm_debug, DEBUG_ON};
-use core::arch::global_asm;
+use core::arch::{asm, global_asm};
 use core::pin::Pin;
 use kernel::bindings;
 use kernel::c_types::c_void;
@@ -186,6 +186,18 @@ impl<T> RkvmPage<T> {
     }
 }
 
+pub(crate) fn rkvm_irq_disable() {
+    unsafe {
+        asm!("cli");
+    }
+}
+
+pub(crate) fn rkvm_irq_enable() {
+    unsafe {
+        asm!("sti");
+    }
+}
+
 #[allow(dead_code)]
 pub(crate) struct Vcpu {
     pub(crate) guest: Ref<GuestWrapper>,
@@ -354,9 +366,7 @@ impl VcpuWrapper {
             vcpuinner.guest_state.rip = rip;
         }
         loop {
-            unsafe {
-                bindings::rkvm_irq_disable();
-            }
+            rkvm_irq_disable();
             let has_err_;
             {
                 let vcpuinner = self.vcpuinner.lock();
@@ -379,9 +389,7 @@ impl VcpuWrapper {
             );
 
             if has_err_ == 1 {
-                unsafe {
-                    bindings::rkvm_irq_enable();
-                }
+                rkvm_irq_enable();
                 let mut vcpuinner = self.vcpuinner.lock();
                 dump_vmcs();
                 let host_rsp = vmcs_read64(VmcsField::HOST_RSP);
@@ -400,9 +408,7 @@ impl VcpuWrapper {
 
                 return -1;
             }
-            unsafe {
-                bindings::rkvm_irq_enable();
-            }
+            rkvm_irq_enable();
             {
                 let mut vcpuinner = self.vcpuinner.lock();
 

--- a/samples/rust/rust_kvm/x86reg.rs
+++ b/samples/rust/rust_kvm/x86reg.rs
@@ -1,4 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0
+use crate::{rkvm_debug, DEBUG_ON};
+use core::arch::asm;
+use core::cfg;
 
 //control registers
 #[allow(dead_code)]
@@ -18,7 +21,7 @@ pub(crate) struct Cr4 {
 }
 
 impl Cr4 {
-    pub(crate) const CR4_ENABLE_VMX: usize = 13;
+    pub(crate) const CR4_ENABLE_VMX: usize = 1 << 13;
 }
 
 #[repr(u64)]
@@ -53,4 +56,22 @@ pub(crate) enum X86Msr {
     TRUE_PROCBASED_CTLS = 0x048e,
     TRUE_EXIT_CTLS = 0x048f,
     TRUE_ENTRY_CTLS = 0x490,
+}
+
+pub(crate) fn read_cr4() -> u64 {
+    let val: u64;
+    unsafe {
+        asm!("mov {0}, cr4",
+            out(reg) val
+        );
+    }
+    return val;
+}
+
+pub(crate) fn write_cr4(val: u64) {
+    unsafe {
+        asm!("mov  cr4, {0}",
+            in(reg) val
+        );
+    }
 }


### PR DESCRIPTION
Memory clobbering is default in rust inline asm, so we don't need any options

Signed-off-by: Zhou Haoan <tvavbb@126.com>