### PR TITLE
Refactor some inline asm function from C into Rust

### DIFF
--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -80,7 +80,6 @@ unsigned long native2_read_cr3(void);
 unsigned long native2_read_cr4(void);
 void native_write_cr4(unsigned long val);
 unsigned long cr4_read_shadow(void);
-void rkvm_vmxon(u64 addr);
 void rkvm_vmxoff(void);
 
 void rkvm_wrgsbase(unsigned long gs);

--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -77,7 +77,6 @@ static inline unsigned long native_read_cr4(void)
 unsigned long native2_read_cr0(void);
 unsigned long native2_read_cr2(void);
 unsigned long native2_read_cr3(void);
-unsigned long native2_read_cr4(void);
 void native_write_cr4(unsigned long val);
 unsigned long cr4_read_shadow(void);
 void rkvm_vmxoff(void);

--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -87,8 +87,6 @@ unsigned long rkvm_rdfsbase(void);
 unsigned short rkvm_read_ldt(void);
 void rkvm_load_ldt(unsigned short sel);
 
-u64 rkvm_rflags_read(void);
-
 #ifdef CONFIG_X86_INTEL_MEMORY_PROTECTION_KEYS
 static inline u32 rdpkru(void)
 {

--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -74,9 +74,7 @@ static inline unsigned long native_read_cr4(void)
 	return val;
 }
 
-unsigned long native2_read_cr0(void);
-unsigned long native2_read_cr2(void);
-unsigned long native2_read_cr3(void);
+
 void native_write_cr4(unsigned long val);
 unsigned long cr4_read_shadow(void);
 void rkvm_vmxoff(void);

--- a/arch/x86/include/asm/special_insns.h
+++ b/arch/x86/include/asm/special_insns.h
@@ -92,8 +92,6 @@ unsigned short rkvm_read_ldt(void);
 void rkvm_load_ldt(unsigned short sel);
 
 u64 rkvm_rflags_read(void);
-void rkvm_irq_disable(void);
-void rkvm_irq_enable(void);
 
 #ifdef CONFIG_X86_INTEL_MEMORY_PROTECTION_KEYS
 static inline u32 rdpkru(void)

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -460,12 +460,6 @@ void rkvm_load_ldt(unsigned short sel)
 }
 EXPORT_SYMBOL(rkvm_load_ldt);
 
-u64 rkvm_rflags_read()
-{
-	return native_save_fl();
-}
-EXPORT_SYMBOL(rkvm_rflags_read);
-
 void cr4_update_irqsoff(unsigned long set, unsigned long clear)
 {
 	unsigned long newval, cr4 = this_cpu_read(cpu_tlbstate.cr4);

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -406,16 +406,6 @@ set_register:
 EXPORT_SYMBOL_GPL(native_write_cr4);
 #endif
 
-unsigned long __no_profile native2_read_cr4(void)
-{
-	unsigned long val;
-
-	/* CR4 always exists on x86_64. */
-	asm volatile("mov %%cr4,%0\n\t" : "=r" (val) : __FORCE_ORDER);
-	return val;
-}
-EXPORT_SYMBOL_GPL(native2_read_cr4);
-
 unsigned long __no_profile native2_read_cr3(void)
 {
    return __native_read_cr3();

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -434,16 +434,6 @@ unsigned long __no_profile native2_read_cr0(void)
 }
 EXPORT_SYMBOL_GPL(native2_read_cr0);
 
-void rkvm_vmxon(u64 addr)
-{
-	unsigned long cr4;
-	cr4 = native_read_cr4();
-	cr4 |= X86_CR4_VMXE;
-	native_write_cr4(cr4);
-	asm volatile ("vmxon %0" : : "m"(addr));
-}
-EXPORT_SYMBOL(rkvm_vmxon);
-
 void rkvm_vmxoff()
 {
 	unsigned long cr4;

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -504,18 +504,6 @@ u64 rkvm_rflags_read()
 }
 EXPORT_SYMBOL(rkvm_rflags_read);
 
-void rkvm_irq_disable(void)
-{
-       asm volatile("cli": : :"memory");
-}
-EXPORT_SYMBOL(rkvm_irq_disable);
-
-void rkvm_irq_enable(void)
-{
-        asm volatile("sti": : :"memory");
-}
-EXPORT_SYMBOL(rkvm_irq_enable);
-
 void cr4_update_irqsoff(unsigned long set, unsigned long clear)
 {
 	unsigned long newval, cr4 = this_cpu_read(cpu_tlbstate.cr4);

--- a/arch/x86/kernel/cpu/common.c
+++ b/arch/x86/kernel/cpu/common.c
@@ -406,24 +406,6 @@ set_register:
 EXPORT_SYMBOL_GPL(native_write_cr4);
 #endif
 
-unsigned long __no_profile native2_read_cr3(void)
-{
-   return __native_read_cr3();
-}
-EXPORT_SYMBOL_GPL(native2_read_cr3);
-
-unsigned long __no_profile native2_read_cr2(void)
-{
-   return native_read_cr2();
-}
-EXPORT_SYMBOL_GPL(native2_read_cr2);
-
-unsigned long __no_profile native2_read_cr0(void)
-{
-   return native_read_cr0();
-}
-EXPORT_SYMBOL_GPL(native2_read_cr0);
-
 void rkvm_vmxoff()
 {
 	unsigned long cr4;

--- a/samples/rust/rust_kvm/rust_kvm.rs
+++ b/samples/rust/rust_kvm/rust_kvm.rs
@@ -176,7 +176,7 @@ fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
         Err(err) => return Err(/*Error::ENOMEM*/ err),
     };
 
-    let vmxe = unsafe { bindings::native2_read_cr4() & Cr4::CR4_ENABLE_VMX as u64 };
+    let vmxe = read_cr4() & Cr4::CR4_ENABLE_VMX as u64;
 
     rkvm_debug!("Rust kvm :vmxe {:}\n", vmxe);
 

--- a/samples/rust/rust_kvm/rust_kvm.rs
+++ b/samples/rust/rust_kvm/rust_kvm.rs
@@ -2,6 +2,7 @@
 
 //! Rust KVM for VMX
 #[allow(missing_docs)]
+use core::arch::asm;
 use kernel::c_types::c_void;
 use kernel::mm::virt::Area;
 use kernel::prelude::*;
@@ -153,6 +154,20 @@ impl Drop for RustMiscdev {
 }
 
 static mut VMXON_VMCS: Option<RkvmPage> = None;
+fn rkvm_vmxon(addr: u64) {
+    let mut cr4: u64 = read_cr4();
+    cr4 |= Cr4::CR4_ENABLE_VMX as u64;
+    write_cr4(cr4);
+    rkvm_debug!("written new cr4 value\n");
+    unsafe {
+        asm!(
+            "vmxon ({0})",
+            in(reg) &addr,
+            options(att_syntax)
+        );
+    }
+}
+
 fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
     let revision_id = state.inner.lock().vmcsconf.revision_id;
     let vmcs = alloc_vmcs(revision_id);
@@ -161,7 +176,7 @@ fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
         Err(err) => return Err(/*Error::ENOMEM*/ err),
     };
 
-    let vmxe = unsafe { bindings::native2_read_cr4() & bit(x86reg::Cr4::CR4_ENABLE_VMX) };
+    let vmxe = unsafe { bindings::native2_read_cr4() & Cr4::CR4_ENABLE_VMX as u64 };
 
     rkvm_debug!("Rust kvm :vmxe {:}\n", vmxe);
 
@@ -174,7 +189,7 @@ fn rkvm_set_vmxon(state: &RkvmState) -> Result<u32> {
 
         rkvm_debug!(" pa = {:x}\n", pa);
 
-        bindings::rkvm_vmxon(pa);
+        rkvm_vmxon(pa);
         VMXON_VMCS = Some(vmcs);
     }
     Ok(0)

--- a/samples/rust/rust_kvm/vcpu.rs
+++ b/samples/rust/rust_kvm/vcpu.rs
@@ -4,6 +4,7 @@ use crate::exit::*;
 use crate::mmu::*;
 use crate::vmcs::*;
 use crate::vmstat::*;
+use crate::x86reg::*;
 use crate::{rkvm_debug, DEBUG_ON};
 use core::arch::{asm, global_asm};
 use core::pin::Pin;
@@ -398,7 +399,8 @@ impl VcpuWrapper {
                 }
 
                 let ret = vmcs_read32(VmcsField::VM_INSTRUCTION_ERROR);
-                let rflags = unsafe { bindings::rkvm_rflags_read() };
+                let rflags = read_rflags();
+                
                 pr_err!(
                     "run loop after _vmx_vcpu_run, rflags={:x},ret={:x} \n",
                     rflags,

--- a/samples/rust/rust_kvm/vmcs.rs
+++ b/samples/rust/rust_kvm/vmcs.rs
@@ -741,9 +741,9 @@ impl VmcsConfig {
         Ok(0)
     }
     pub(crate) fn set_host_constant_vmcs(&self) {
-        let mut cr0 = unsafe { bindings::native2_read_cr0() };
+        let mut cr0 = read_cr0();
         cr0 &= !(Cr0::CR0_TS as u64);
-        let cr3 = unsafe { bindings::native2_read_cr3() };
+        let cr3 = read_cr3();
         // let cr4 = unsafe { bindings::cr4_read_shadow() };
         vmcs_write64(VmcsField::HOST_CR0, cr0);
         vmcs_write64(VmcsField::HOST_CR3, cr3);

--- a/samples/rust/rust_kvm/vmcs.rs
+++ b/samples/rust/rust_kvm/vmcs.rs
@@ -322,7 +322,7 @@ pub(crate) struct VmcsConfig {
 }
 
 fn vmcs_status() -> Result {
-    let rflags = unsafe { bindings::rkvm_rflags_read() };
+    let rflags = read_rflags();
     if rflags & (RFlags::FLAGS_ZF as u64 + RFlags::FLAGS_CF as u64) != 0 {
         return Err(Error::EINVAL);
     }

--- a/samples/rust/rust_kvm/x86reg.rs
+++ b/samples/rust/rust_kvm/x86reg.rs
@@ -57,6 +57,36 @@ pub(crate) enum X86Msr {
     TRUE_ENTRY_CTLS = 0x490,
 }
 
+pub(crate) fn read_cr0() -> u64 {
+    let val: u64;
+    unsafe {
+        asm!("mov {0}, cr0",
+            out(reg) val
+        );
+    }
+    return val;
+}
+
+pub(crate) fn read_cr2() -> u64 {
+    let val: u64;
+    unsafe {
+        asm!("mov {0}, cr2",
+            out(reg) val
+        );
+    }
+    return val;
+}
+
+pub(crate) fn read_cr3() -> u64 {
+    let val: u64;
+    unsafe {
+        asm!("mov {0}, cr3",
+            out(reg) val
+        );
+    }
+    return val;
+}
+
 pub(crate) fn read_cr4() -> u64 {
     let val: u64;
     unsafe {

--- a/samples/rust/rust_kvm/x86reg.rs
+++ b/samples/rust/rust_kvm/x86reg.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0
+use crate::{rkvm_debug, DEBUG_ON};
+use core::arch::asm;
 
 //control registers
 #[allow(dead_code)]
@@ -18,7 +20,7 @@ pub(crate) struct Cr4 {
 }
 
 impl Cr4 {
-    pub(crate) const CR4_ENABLE_VMX: usize = 13;
+    pub(crate) const CR4_ENABLE_VMX: usize = 1 << 13;
 }
 
 #[repr(u64)]
@@ -53,4 +55,22 @@ pub(crate) enum X86Msr {
     TRUE_PROCBASED_CTLS = 0x048e,
     TRUE_EXIT_CTLS = 0x048f,
     TRUE_ENTRY_CTLS = 0x490,
+}
+
+pub(crate) fn read_cr4() -> u64 {
+    let val: u64;
+    unsafe {
+        asm!("mov {0}, cr4",
+            out(reg) val
+        );
+    }
+    return val;
+}
+
+pub(crate) fn write_cr4(val: u64) {
+    unsafe {
+        asm!("mov  cr4, {0}",
+            in(reg) val
+        );
+    }
 }

--- a/samples/rust/rust_kvm/x86reg.rs
+++ b/samples/rust/rust_kvm/x86reg.rs
@@ -104,3 +104,15 @@ pub(crate) fn write_cr4(val: u64) {
         );
     }
 }
+
+#[no_mangle]
+pub(crate) fn read_rflags() -> u64 {
+    let flags: u64;
+    unsafe {
+        asm!("pushf",
+            "pop {0}",
+            out(reg) flags,
+        );
+    }
+    flags
+}


### PR DESCRIPTION
- Refactor of irq_enable/disable
- Refactor of vmxon
- Refactor of read_cr4, write_cr4
- Refactor of read_cr0, read_cr2, read_cr3
- Refactor of read_rflags : 
      After read rflags in C function, some flags were changed. However, read rflags in Rust wouldn't change any flags. This my caused by some operations performed by bindgen.